### PR TITLE
Added option to disable timestamps in output

### DIFF
--- a/bin/taskrunner
+++ b/bin/taskrunner
@@ -66,6 +66,10 @@ def parse_args():
                       type="choice", choices=choices, default='INFO',
                       help="Select logging level out of %s. Default is 'INFO'"
                            % choices)
+    parser.add_option("--no-timestamp", dest="log_time",
+                      action="store_false", default=True,
+                      help="Do not write timestamp at the beggining of each"
+                      " log line.")
 
     options, tasks = parser.parse_args()
     if not tasks:
@@ -232,7 +236,14 @@ class RedefinitionError(Exception):
 
 if __name__ == '__main__':
     task_names, options = parse_args()
-    taskrunner.logs.set_logging_options(log_level=options.log_level)
+
+    if options.log_time:
+        log_format = taskrunner.logs.FORMAT_TIME
+    else:
+        log_format = taskrunner.logs.FORMAT_SIMPLE
+    taskrunner.logs.set_logging_options(
+        log_format=log_format,
+        log_level=options.log_level)
 
     modules = dict(import_python_file(f) for f in options.files)
     pipeline = get_pipeline(modules, task_names)

--- a/taskrunner/logs.py
+++ b/taskrunner/logs.py
@@ -16,7 +16,8 @@
 
 import logging
 
-LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+FORMAT_SIMPLE = '%(name)s - %(levelname)s - %(message)s'
+FORMAT_TIME = '%(asctime)s - ' + FORMAT_SIMPLE
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = \
     ['\033[1;3%sm' % i for i in range(8)]
 RESET = '\033[0m'
@@ -39,7 +40,7 @@ LOG_LEVEL_COLORS = {
 }
 
 
-def set_logging_options(color=True, log_format=LOG_FORMAT, log_level='INFO'):
+def set_logging_options(color=True, log_format=FORMAT_TIME, log_level='INFO'):
     """Make the logging output pretty.
 
     :param color: if True, give different colors to the log level names


### PR DESCRIPTION
This option --no-timestamp provides a way how to let other tools
(like Jenkins) handle timestamping of the output.
