### PR TITLE
Log taskrunner start/stop/end and cleanup-skipping

### DIFF
--- a/bin/taskrunner
+++ b/bin/taskrunner
@@ -21,6 +21,7 @@ the command line will be read from the dynamically loaded Python modules, put
 into a pipeline and executed by taskrunner.
 """
 
+import datetime
 import os
 import imp
 import sys
@@ -249,9 +250,15 @@ if __name__ == '__main__':
     pipeline = get_pipeline(modules, task_names)
     redefine_configuration(pipeline, options.redefine)
 
+    LOG.info("************* TaskRunner start [%s UTC] *************"
+             % datetime.datetime.utcnow())
     try:
         taskrunner.execute(pipeline, cleanup=options.cleanup)
+        LOG.info("************* TaskRunner end [%s UTC] *************"
+                 % datetime.datetime.utcnow())
     except taskrunner.TaskExecutionException, ex:
         _log_errors(ex.context['_taskrunner']['run_failures'],
                     ex.context['_taskrunner']['cleanup_failures'])
+        LOG.info("************* TaskRunner failed [%s UTC] *************"
+                 % datetime.datetime.utcnow())
         sys.exit(1)

--- a/taskrunner/main.py
+++ b/taskrunner/main.py
@@ -86,6 +86,9 @@ def execute(pipeline, cleanup='always', context=None):
             or (cleanup == 'on_success' and not run_failures)
             or (cleanup == 'on_failure' and run_failures)):
         _cleanup_tasks(executed_tasks, context)
+    else:
+        LOG.info('Skipping cleanup: cleanup=%s and failures=%s'
+                 % (cleanup, run_failures))
     cleanup_failures = context['_taskrunner']['cleanup_failures']
 
     LOG.debug("Context shared between task at finish:\n%s", context)


### PR DESCRIPTION
Log when TaskRunner starts, stops or fails.
Also log when cleanup get's skipped.

This should remove the possible confusion that sometimes,
when taskrunner is executed with clean=never or in similar
way, it's not clear from the output if execution really
finished completely or if it died somewhere (unless
the Tasks executed do log their end on their own).
