### PR TITLE
Fix KeyError with multiple files and includes

### DIFF
--- a/bin/taskrunner
+++ b/bin/taskrunner
@@ -131,15 +131,17 @@ def get_var_from_module(module, var):
     :param var: string with the variable name, or something like `moduleA.name`
     """
     parts = var.split('.', 1)
-    if len(parts) == 1:
-        if var in vars(module):
+    try:
+        if len(parts) == 1:
             return vars(module)[var]
         else:
-            return None
-    else:
-        # the var is in an included module
-        module = vars(module)[parts[0]]
-        return get_var_from_module(module, parts[1])
+            # the var is in an included module
+            module = vars(module)[parts[0]]
+            return get_var_from_module(module, parts[1])
+    except KeyError:
+        # module does not contain specified var
+        # or nested module
+        return None
 
 
 def get_pipeline(modules, var_names):


### PR DESCRIPTION
When multiple configuration files using -f
and target pipeline which is actualy include in one of this files,
are provided it causes KeyError when taskrunner tries to find
included pipeline in a configuration file (module)
which is not the one including it.
